### PR TITLE
:bug: (app/helm-dashboard): allow * when 'allowWriteActions' is enabled

### DIFF
--- a/charts/helm-dashboard/Chart.yaml
+++ b/charts/helm-dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: helm-dashboard
 description: A GUI Dashboard for Helm by Komodor
-version: 2.1.0
+version: 2.1.1
 appVersion: 1.2.0
 kubeVersion: '>=1.20'
 home: https://github.com/komodorio/helm-dashboard

--- a/charts/helm-dashboard/README.md
+++ b/charts/helm-dashboard/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
-  ![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat)
+  ![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat)
   ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat)
 
 </div>

--- a/charts/helm-dashboard/templates/rbac.yaml
+++ b/charts/helm-dashboard/templates/rbac.yaml
@@ -19,7 +19,7 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
   {{- if .Values.rbac.allowWriteActions }}
-    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+    verbs: ["*"]
   {{- else }}
     verbs: ["get", "list", "watch"]
   {{- end }}

--- a/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/deployment.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/rbac.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/rbac.yaml
@@ -1,38 +1,38 @@
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+    verbs: ["get", "list", "watch"]
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 roleRef:

--- a/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/service.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/storage.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/storage.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard-data
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec: 

--- a/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/tests/test-connection.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/default/helm-dashboard/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "helm-dashboard-test-connection"
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
   annotations:

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/deployment.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     podAnnotations: enabled
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/ingress.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     annotations: enabled
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/neworkpolicy.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/neworkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
     annotations: enabled
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/rbac.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/rbac.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled
     commonLabels02: enabled
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled
@@ -27,16 +27,16 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+    verbs: ["*"]
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/service.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     annotations: enabled
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/storage.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/storage.yaml
@@ -8,7 +8,7 @@ metadata:
     annotations: enabled
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
     commonLabels01: enabled

--- a/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/tests/test-connection.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/full/helm-dashboard/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "helm-dashboard-test-connection"
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
   annotations:

--- a/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/deployment.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/ingress.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/rbac.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/rbac.yaml
@@ -1,38 +1,38 @@
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["*"]
 ---
-# Source: helm-dashboard/templates/serviceaccount.yaml
+# Source: helm-dashboard/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 roleRef:

--- a/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/service.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/storage.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/storage.yaml
@@ -6,7 +6,7 @@ metadata:
   name: helm-dashboard-data
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
 spec: 

--- a/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/tests/test-connection.yaml
+++ b/charts/helm-dashboard/~develop/validation/compiled/writable/helm-dashboard/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "helm-dashboard-test-connection"
   labels:
     app.kubernetes.io/name: helm-dashboard
-    helm.sh/chart: helm-dashboard-2.1.0
+    helm.sh/chart: helm-dashboard-2.1.1
     app.kubernetes.io/instance: helm-dashboard
     app.kubernetes.io/managed-by: Helm
   annotations:


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->

Allow `*` verbs on RBAC when `allowWriteActions` is enabled.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only allow specific verbs for all resources


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some charts (like cert-manager or kasten) uses `*` with verbs on their RBAC, which can't be deployed with the current `helm-dashboard` RBAC (privilege escalation)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting or renaming that would not cause existing functionality to change)
- [ ] Refactoring (no functional changes and no API changes)
- [ ] Build-related changes (improve Github Action workflows)
- [ ] Documentation content changes (add or improve existing documentation)
- [ ] Other (please describe):

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
