### PR TITLE
:technologist: (renovate): add command to bump automatically a chart

### DIFF
--- a/.github/workflows/lint.helm.yml
+++ b/.github/workflows/lint.helm.yml
@@ -5,10 +5,12 @@ on: # yamllint disable-line rule:truthy
     types: [opened, synchronize]
     paths:
       # NOTE: only few changes should trigger this pipeline
-      - charts/*/templates/**
       - charts/*/Chart.lock
       - charts/*/Chart.yaml
       - charts/*/README.md
+      - charts/*/README.md.gotmpl
+      - charts/*/templates/**
+      - charts/*/values.schema.json
       - charts/*/values.yaml
 
 concurrency:
@@ -53,10 +55,12 @@ jobs:
           dir_names: true
           dir_names_max_depth: 2
           files: |
-            charts/*/templates/**
             charts/*/Chart.lock
             charts/*/Chart.yaml
             charts/*/README.md
+            charts/*/README.md.gotmpl
+            charts/*/templates/**
+            charts/*/values.schema.json
             charts/*/values.yaml
           json: true
       - id: set-matrix

--- a/.github/workflows/security.helm.yml
+++ b/.github/workflows/security.helm.yml
@@ -4,7 +4,13 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, synchronize]
     paths:
-      - charts/**
+      # NOTE: only few changes should trigger this pipeline
+      - charts/*/Chart.lock
+      - charts/*/Chart.yaml
+      - charts/*/README.md
+      - charts/*/templates/**
+      - charts/*/values.schema.json
+      - charts/*/values.yaml
 
 concurrency:
   group: ${{ github.ref }}/helm-security
@@ -26,10 +32,11 @@ jobs:
           dir_names: true
           dir_names_max_depth: 2
           files: |
-            charts/*/templates/**
             charts/*/Chart.lock
             charts/*/Chart.yaml
             charts/*/README.md
+            charts/*/templates/**
+            charts/*/values.schema.json
             charts/*/values.yaml
           json: true
       - id: set-matrix

--- a/.github/workflows/test.helm.yml
+++ b/.github/workflows/test.helm.yml
@@ -4,7 +4,13 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     types: [ opened, synchronize ]
     paths:
-      - charts/**
+      # NOTE: only few changes should trigger this pipeline
+      - charts/*/Chart.lock
+      - charts/*/Chart.yaml
+      - charts/*/README.md
+      - charts/*/templates/**
+      - charts/*/values.schema.json
+      - charts/*/values.yaml
 
 concurrency:
   group: ${{ github.ref }}/helm-test
@@ -30,10 +36,11 @@ jobs:
           dir_names: true
           dir_names_max_depth: 2
           files: |
-            charts/*/templates/**
             charts/*/Chart.lock
             charts/*/Chart.yaml
             charts/*/README.md
+            charts/*/templates/**
+            charts/*/values.schema.json
             charts/*/values.yaml
           json: true
       - id: set-matrix

--- a/charts/cert-manager-issuers/.justfile
+++ b/charts/cert-manager-issuers/.justfile
@@ -160,6 +160,29 @@ git-commit-package +OPTS="": build-external
   git add ~develop/validation/ README.md
   git commit --message ":package: (apps/{{ chart_name }}): rebuild all packaging files" {{ OPTS }}
 
+# automatically bump the chart version if something changes (used by Renovate).
+[private]
+[no-exit-message]
+renovate-update-chart +BASE_BRANCH="main":
+  #!/usr/bin/env bash
+  if git diff --cached {{ BASE_BRANCH }} | grep --silent '^+appVersion:'; then
+    just renovate-bump-minor {{ BASE_BRANCH }}
+  else
+    just renovate-bump-patch {{ BASE_BRANCH }}
+  fi
+
+# bump the current chart version (minor).
+[private]
+[no-exit-message]
+@renovate-bump-minor +BASE_BRANCH="main":
+  git show {{ BASE_BRANCH }}:charts/{{ chart_name }}/Chart.yaml | yq --inplace eval-all '[select(fi == 0), select(fi == 1)] | .[0].version = (.[1].version | split(".") | map(. tag = "!!int") | [.[0], .[1] + 1, 0] | join(".")) | .[0]' Chart.yaml -
+
+# bump the current chart version (patch).
+[private]
+[no-exit-message]
+@renovate-bump-patch +BASE_BRANCH="main":
+  git show {{ BASE_BRANCH }}:charts/{{ chart_name }}/Chart.yaml | yq --inplace eval-all '[select(fi == 0), select(fi == 1)] | .[0].version = (.[1].version | split(".") | map(. tag = "!!int") | [.[0], .[1], .[2] + 1] | join(".")) | .[0]' Chart.yaml -
+
 # (lib only) print a trace of simple commands then run it. If it runs inside
 #            Github Actions, it will also group all outputs inside a block to
 #            simplify CI logs.

--- a/charts/jellyfin/.justfile
+++ b/charts/jellyfin/.justfile
@@ -183,6 +183,29 @@ git-commit-package +OPTS="": build-external
   git add ~develop/validation/ README.md
   git commit --message ":package: (apps/{{ chart_name }}): rebuild all packaging files" {{ OPTS }}
 
+# automatically bump the chart version if something changes (used by Renovate).
+[private]
+[no-exit-message]
+renovate-update-chart +BASE_BRANCH="main":
+  #!/usr/bin/env bash
+  if git diff --cached {{ BASE_BRANCH }} | grep --silent '^+appVersion:'; then
+    just renovate-bump-minor {{ BASE_BRANCH }}
+  else
+    just renovate-bump-patch {{ BASE_BRANCH }}
+  fi
+
+# bump the current chart version (minor).
+[private]
+[no-exit-message]
+@renovate-bump-minor +BASE_BRANCH="main":
+  git show {{ BASE_BRANCH }}:charts/{{ chart_name }}/Chart.yaml | yq --inplace eval-all '[select(fi == 0), select(fi == 1)] | .[0].version = (.[1].version | split(".") | map(. tag = "!!int") | [.[0], .[1] + 1, 0] | join(".")) | .[0]' Chart.yaml -
+
+# bump the current chart version (patch).
+[private]
+[no-exit-message]
+@renovate-bump-patch +BASE_BRANCH="main":
+  git show {{ BASE_BRANCH }}:charts/{{ chart_name }}/Chart.yaml | yq --inplace eval-all '[select(fi == 0), select(fi == 1)] | .[0].version = (.[1].version | split(".") | map(. tag = "!!int") | [.[0], .[1], .[2] + 1] | join(".")) | .[0]' Chart.yaml -
+
 # (lib only) print a trace of simple commands then run it. If it runs inside
 #            Github Actions, it will also group all outputs inside a block to
 #            simplify CI logs.


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->

Add a `just` command to bump the charts automatically on Renovate updates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Just lazy to update manually each Renovate updates

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting or renaming that would not cause existing functionality to change)
- [ ] Refactoring (no functional changes and no API changes)
- [X] Build-related changes (improve Github Action workflows)
- [ ] Documentation content changes (add or improve existing documentation)
- [ ] Other (please describe):

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
